### PR TITLE
use Yajl instead of to_json

### DIFF
--- a/lib/fluent/plugin/out_jsonbucket.rb
+++ b/lib/fluent/plugin/out_jsonbucket.rb
@@ -1,3 +1,5 @@
+require "yajl"
+
 module Fluent
     class JsonbucketOutput < Fluent::Output
         Fluent::Plugin.register_output('jsonbucket', self)
@@ -14,7 +16,7 @@ module Fluent
         def emit(tag, es, chain)
             es.each {|time,record|
                 chain.next
-                bucket = {@json_key => record.to_json}
+                bucket = {@json_key => Yajl.dump(record)}
                 Fluent::Engine.emit(@output_tag, time, bucket)
             }
         end 


### PR DESCRIPTION
I have found that fluentd force encoding to ASCII-8BIT, as consequence when you call to_json method the encoding fail.

```
2014-02-25 16:52:00 +0900 [warn]: emit transaction failed  error_class=Encoding::UndefinedConversionError error=#<Encoding::UndefinedConversionError: "\xE
6" from ASCII-8BIT to UTF-8>
```

It seems to be resolved by the use Yajl.
